### PR TITLE
Add activity navigation for main sections

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -14,8 +14,20 @@
         tools:targetApi="31">
 
         <activity
+            android:name=".ArtistasActivity"
+            android:parentActivityName=".MainActivity" />
+
+        <activity
             android:name=".EventosActivity"
             android:parentActivityName=".ArtistasActivity" />
+
+        <activity
+            android:name=".EntradasActivity"
+            android:parentActivityName=".MainActivity" />
+
+        <activity
+            android:name=".LugaresActivity"
+            android:parentActivityName=".MainActivity" />
 
 
         <activity

--- a/app/src/main/java/es/upv/etsit/trabajoaplicusa/EntradasActivity.java
+++ b/app/src/main/java/es/upv/etsit/trabajoaplicusa/EntradasActivity.java
@@ -1,4 +1,27 @@
 package es.upv.etsit.trabajoaplicusa;
 
-public class EntradasActivity {
+import android.os.Bundle;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.Toolbar;
+
+public class EntradasActivity extends AppCompatActivity {
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_entradas);
+
+        Toolbar toolbar = findViewById(R.id.toolbar);
+        setSupportActionBar(toolbar);
+        if (getSupportActionBar() != null) {
+            getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+            getSupportActionBar().setDisplayShowHomeEnabled(true);
+            getSupportActionBar().setTitle(getString(R.string.entradas));
+        }
+    }
+
+    @Override
+    public boolean onSupportNavigateUp() {
+        onBackPressed();
+        return true;
+    }
 }

--- a/app/src/main/java/es/upv/etsit/trabajoaplicusa/LugaresActivity.java
+++ b/app/src/main/java/es/upv/etsit/trabajoaplicusa/LugaresActivity.java
@@ -1,4 +1,27 @@
 package es.upv.etsit.trabajoaplicusa;
 
-public class LugaresActivity {
+import android.os.Bundle;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.Toolbar;
+
+public class LugaresActivity extends AppCompatActivity {
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_lugares);
+
+        Toolbar toolbar = findViewById(R.id.toolbar);
+        setSupportActionBar(toolbar);
+        if (getSupportActionBar() != null) {
+            getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+            getSupportActionBar().setDisplayShowHomeEnabled(true);
+            getSupportActionBar().setTitle(getString(R.string.lugares));
+        }
+    }
+
+    @Override
+    public boolean onSupportNavigateUp() {
+        onBackPressed();
+        return true;
+    }
 }

--- a/app/src/main/java/es/upv/etsit/trabajoaplicusa/MainActivity.java
+++ b/app/src/main/java/es/upv/etsit/trabajoaplicusa/MainActivity.java
@@ -49,8 +49,22 @@ public class MainActivity extends AppCompatActivity {
     }
 
     private void openSection(String section) {
-        Intent intent = new Intent(this, ArtistasActivity.class);
-        intent.putExtra("section", section);
+        Intent intent;
+        switch (section) {
+            case "eventos":
+                intent = new Intent(this, EventosActivity.class);
+                break;
+            case "tickets":
+                intent = new Intent(this, EntradasActivity.class);
+                break;
+            case "lugares":
+                intent = new Intent(this, LugaresActivity.class);
+                break;
+            default:
+                intent = new Intent(this, ArtistasActivity.class);
+                intent.putExtra("section", section);
+                break;
+        }
         startActivity(intent);
     }
 

--- a/app/src/main/res/layout/activity_entradas.xml
+++ b/app/src/main/res/layout/activity_entradas.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <androidx.appcompat.widget.Toolbar
+        android:id="@+id/toolbar"
+        android:layout_width="0dp"
+        android:layout_height="?attr/actionBarSize"
+        android:background="?attr/colorPrimary"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <TextView
+        android:id="@+id/tvTitle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/entradas_title"
+        android:textSize="20sp"
+        android:textStyle="bold"
+        app:layout_constraintTop_toBottomOf="@id/toolbar"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:layout_marginTop="24dp" />
+
+    <TextView
+        android:id="@+id/tvMessage"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/entradas_msg"
+        app:layout_constraintTop_toBottomOf="@id/tvTitle"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:layout_marginTop="8dp" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_lugares.xml
+++ b/app/src/main/res/layout/activity_lugares.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <androidx.appcompat.widget.Toolbar
+        android:id="@+id/toolbar"
+        android:layout_width="0dp"
+        android:layout_height="?attr/actionBarSize"
+        android:background="?attr/colorPrimary"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <TextView
+        android:id="@+id/tvTitle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/lugares_title"
+        android:textSize="20sp"
+        android:textStyle="bold"
+        app:layout_constraintTop_toBottomOf="@id/toolbar"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:layout_marginTop="24dp" />
+
+    <TextView
+        android:id="@+id/tvMessage"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/lugares_msg"
+        app:layout_constraintTop_toBottomOf="@id/tvTitle"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:layout_marginTop="8dp" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -33,6 +33,11 @@
     <string name="lugares">LUGARES</string>
     <string name="entradas">ENTRADAS</string>
 
+    <string name="entradas_title">Entradas</string>
+    <string name="entradas_msg">Compra tus entradas</string>
+    <string name="lugares_title">Lugares</string>
+    <string name="lugares_msg">Consulta los recintos</string>
+
     <!-- Botones -->
     <string name="btn_see_artists">VER ARTISTAS</string>
     <string name="btn_see_schedule">VER HORARIOS</string>


### PR DESCRIPTION
## Summary
- add `EntradasActivity` and `LugaresActivity`
- register new activities in the manifest
- create simple layouts for Entradas and Lugares
- support titles/messages for new sections
- update `MainActivity.openSection` logic

## Testing
- `./gradlew assembleDebug` *(fails: unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68690af67ba08325b81b4ce7b41b37fe