### PR TITLE
Update missing event images

### DIFF
--- a/app/src/main/java/es/upv/etsit/trabajoaplicusa/EventosActivity.java
+++ b/app/src/main/java/es/upv/etsit/trabajoaplicusa/EventosActivity.java
@@ -80,7 +80,11 @@ public class EventosActivity extends AppCompatActivity {
                 int resourceId = getResources().getIdentifier(drawableName, "drawable", getPackageName());
                 if (resourceId != 0) {
                     ivArtistImage.setImageResource(resourceId);
+                } else {
+                    ivArtistImage.setImageResource(R.drawable.ic_artista);
                 }
+            } else {
+                ivArtistImage.setImageResource(R.drawable.ic_artista);
             }
         } else {
             ivArtistImage.setVisibility(ImageView.GONE);
@@ -106,12 +110,12 @@ public class EventosActivity extends AppCompatActivity {
                 events.add(new SectionContent(
                         "Mad Cool Festival 2025",
                         "Actuación principal en el escenario Madrid\nFecha: 15 de Julio 2025\nHora: 22:00",
-                        "drawable/mad_cool_stage"
+                        "drawable/mad_cool"
                 ));
                 events.add(new SectionContent(
                         "Meet & Greet",
                         "Encuentro con fans antes del concierto\nFecha: 15 de Julio 2025\nHora: 19:00",
-                        "drawable/meet_greet"
+                        "drawable/ic_festival"
                 ));
                 break;
 
@@ -119,12 +123,12 @@ public class EventosActivity extends AppCompatActivity {
                 events.add(new SectionContent(
                         "Primavera Sound 2025",
                         "Concierto en el escenario Parc del Fòrum\nFecha: 3 de Junio 2025\nHora: 23:30",
-                        "drawable/primavera_stage"
+                        "drawable/primavera_sound"
                 ));
                 events.add(new SectionContent(
                         "Sesión Acústica",
                         "Versión íntima de sus mejores temas\nFecha: 4 de Junio 2025\nHora: 16:00",
-                        "drawable/acoustic_session"
+                        "drawable/ic_festival"
                 ));
                 break;
 
@@ -132,7 +136,7 @@ public class EventosActivity extends AppCompatActivity {
                 events.add(new SectionContent(
                         "Arenal Sound 2025",
                         "Headliner en la playa de Burriana\nFecha: 30 de Julio 2025\nHora: 01:00",
-                        "drawable/arenal_stage"
+                        "drawable/arenal_sound"
                 ));
                 break;
 
@@ -140,12 +144,12 @@ public class EventosActivity extends AppCompatActivity {
                 events.add(new SectionContent(
                         "Viña Rock 2025",
                         "Concierto en el escenario principal\nFecha: 1 de Mayo 2025\nHora: 22:30",
-                        "drawable/vina_stage"
+                        "drawable/vina_rock"
                 ));
                 events.add(new SectionContent(
                         "Firma de Autógrafos",
                         "Sesión de firmas en la tienda oficial\nFecha: 2 de Mayo 2025\nHora: 12:00",
-                        "drawable/autograph_session"
+                        "drawable/ic_festival"
                 ));
                 break;
 
@@ -153,12 +157,12 @@ public class EventosActivity extends AppCompatActivity {
                 events.add(new SectionContent(
                         "Resurrection Fest 2025",
                         "Actuación épica en el escenario principal\nFecha: 25 de Junio 2025\nHora: 23:00",
-                        "drawable/resurrection_stage"
+                        "drawable/resurrection"
                 ));
                 events.add(new SectionContent(
                         "Masterclass",
                         "Clase magistral sobre técnicas de metal\nFecha: 26 de Junio 2025\nHora: 14:00",
-                        "drawable/masterclass"
+                        "drawable/ic_festival"
                 ));
                 break;
 
@@ -167,12 +171,12 @@ public class EventosActivity extends AppCompatActivity {
                 events.add(new SectionContent(
                         "Concierto Principal",
                         "Actuación principal del artista\nFecha: Por confirmar\nHora: Por confirmar",
-                        "drawable/concert_stage"
+                        "drawable/ic_festival"
                 ));
                 events.add(new SectionContent(
                         "Rueda de Prensa",
                         "Entrevistas y declaraciones\nFecha: Por confirmar\nHora: Por confirmar",
-                        "drawable/press_conference"
+                        "drawable/ic_festival"
                 ));
                 break;
         }
@@ -181,7 +185,7 @@ public class EventosActivity extends AppCompatActivity {
         events.add(new SectionContent(
                 "Entrevista Exclusiva",
                 "Charla íntima con el artista\nPrensa especializada\nAcceso VIP requerido",
-                "drawable/interview"
+                "drawable/ic_festival"
         ));
 
         return events;


### PR DESCRIPTION
## Summary
- replace references to nonexistent drawables with `ic_festival`
- fallback to artist placeholder image if the specified drawable isn't found

## Testing
- `./gradlew test` *(fails: Unable to download gradle due to network)*

------
https://chatgpt.com/codex/tasks/task_e_686aa0c7dc888325b4f92d6b7a805522